### PR TITLE
Fix issues with multi container image updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,7 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
           create-resource-group: true
           location: centralus
+          context: orb-publishing
           filters: *integration_test_filters
       - test-update-kubeconfig:
           name: test-update-kubeconfig_region
@@ -377,6 +378,7 @@ workflows:
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
           install-kubectl: true
+          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -385,6 +387,7 @@ workflows:
           executor: azure-aks/default
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
+          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -393,6 +396,7 @@ workflows:
           executor: azure-aks/azure-docker
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
+          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -401,6 +405,7 @@ workflows:
           executor: azure-aks/default
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
+          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -411,6 +416,7 @@ workflows:
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
           delete-service-principal: false
+          context: orb-publishing
           requires:
             - test-cluster-defaults
           filters: *integration_test_filters
@@ -421,11 +427,13 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           create-resource-group: true
           location: centralus
+          context: orb-publishing
           filters: *integration_test_filters
       - azure-aks/install-helm-on-cluster:
           cluster-name: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           enable-cluster-wide-admin-access: true
+          context: orb-publishing
           requires:
             - setup-cluster-helm
           filters: *integration_test_filters
@@ -434,6 +442,7 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           chart: stable/grafana
           release-name: grafana-release
+          context: orb-publishing
           requires:
             - azure-aks/install-helm-on-cluster
           filters: *integration_test_filters
@@ -443,6 +452,7 @@ workflows:
           release-name: grafana-release
           purge: true
           timeout: 600
+          context: orb-publishing
           requires:
             - azure-aks/install-helm-chart
           filters: *integration_test_filters
@@ -452,6 +462,7 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           delete-service-principal: true
           delete-resource-group: true
+          context: orb-publishing
           requires:
             - azure-aks/delete-helm-release
           filters: *integration_test_filters
@@ -467,6 +478,7 @@ workflows:
           node-vm-size: "Standard_DS2_v2"
           no-ssh-key: true
           resource-group-tags: "owner=cci"
+          context: orb-publishing
           no-output-timeout: 30m
           filters: *integration_test_filters
       - create-deployment:
@@ -475,6 +487,7 @@ workflows:
           cluster-name: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl-grp
           install-kubectl: true
+          context: orb-publishing
           requires:
             - setup-cluster-kubectl
           filters: *integration_test_filters
@@ -486,6 +499,7 @@ workflows:
           container-image-updates: "nginx=nginx:1.9.1"
           get-rollout-status: true
           record: true
+          context: orb-publishing
           post-steps:
             - kubernetes/delete-resource:
                 resource-types: "deployments"
@@ -501,6 +515,7 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl-grp
           delete-service-principal: true
           delete-resource-group: false
+          context: orb-publishing
           requires:
             - update-container-image-kubectl
           post-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ orbs:
   orb-tools: circleci/orb-tools@7.3.0
   queue: eddiewebb/queue@1.1.2
   helm: circleci/helm@0.1.0
-  kubernetes: circleci/kubernetes@0.3.0
+  kubernetes: circleci/kubernetes@0.4.0
 
 executors:
   python2-browsers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,11 +241,11 @@ jobs:
             - delete-resource-group:
                 cluster-name: << parameters.cluster-name >>
                 resource-group: << parameters.resource-group >>
-      - unless:
-          condition: << parameters.delete-service-principal >>
-          steps:
-            - delete-service-principal:
-                cluster-name: << parameters.cluster-name >>
+      #- unless:
+      #    condition: << parameters.delete-service-principal >>
+      #    steps:
+      #      - delete-service-principal:
+      #          cluster-name: << parameters.cluster-name >>
   create-deployment:
     parameters:
       executor:
@@ -370,7 +370,6 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
           create-resource-group: true
           location: centralus
-          context: orb-publishing
           filters: *integration_test_filters
       - test-update-kubeconfig:
           name: test-update-kubeconfig_region
@@ -378,7 +377,6 @@ workflows:
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
           install-kubectl: true
-          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -387,7 +385,6 @@ workflows:
           executor: azure-aks/default
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
-          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -396,7 +393,6 @@ workflows:
           executor: azure-aks/azure-docker
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
-          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -405,7 +401,6 @@ workflows:
           executor: azure-aks/default
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
-          context: orb-publishing
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters
@@ -416,7 +411,6 @@ workflows:
           cluster-name: ${RESOURCE_NAME_PREFIX}-orb-test-defaults
           resource-group: ${RESOURCE_NAME_PREFIX}-orb-test-defaults-grp
           delete-service-principal: false
-          context: orb-publishing
           requires:
             - test-cluster-defaults
           filters: *integration_test_filters
@@ -427,13 +421,11 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           create-resource-group: true
           location: centralus
-          context: orb-publishing
           filters: *integration_test_filters
       - azure-aks/install-helm-on-cluster:
           cluster-name: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           enable-cluster-wide-admin-access: true
-          context: orb-publishing
           requires:
             - setup-cluster-helm
           filters: *integration_test_filters
@@ -442,7 +434,6 @@ workflows:
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
           chart: stable/grafana
           release-name: grafana-release
-          context: orb-publishing
           requires:
             - azure-aks/install-helm-on-cluster
           filters: *integration_test_filters
@@ -452,7 +443,6 @@ workflows:
           release-name: grafana-release
           purge: true
           timeout: 600
-          context: orb-publishing
           requires:
             - azure-aks/install-helm-chart
           filters: *integration_test_filters
@@ -460,9 +450,8 @@ workflows:
           name: delete-cluster-helm
           cluster-name: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-helm-grp
-          delete-service-principal: true
+          delete-service-principal: false
           delete-resource-group: true
-          context: orb-publishing
           requires:
             - azure-aks/delete-helm-release
           filters: *integration_test_filters
@@ -478,7 +467,6 @@ workflows:
           node-vm-size: "Standard_DS2_v2"
           no-ssh-key: true
           resource-group-tags: "owner=cci"
-          context: orb-publishing
           no-output-timeout: 30m
           filters: *integration_test_filters
       - create-deployment:
@@ -487,7 +475,6 @@ workflows:
           cluster-name: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl-grp
           install-kubectl: true
-          context: orb-publishing
           requires:
             - setup-cluster-kubectl
           filters: *integration_test_filters
@@ -499,7 +486,6 @@ workflows:
           container-image-updates: "nginx=nginx:1.9.1"
           get-rollout-status: true
           record: true
-          context: orb-publishing
           post-steps:
             - kubernetes/delete-resource:
                 resource-types: "deployments"
@@ -513,9 +499,8 @@ workflows:
           name: delete-cluster-kubectl
           cluster-name: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl
           resource-group: ${RESOURCE_NAME_PREFIX}-aks-orb-test-kubectl-grp
-          delete-service-principal: true
+          delete-service-principal: false
           delete-resource-group: false
-          context: orb-publishing
           requires:
             - update-container-image-kubectl
           post-steps:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Full usage examples can be found on the Azure AKS orb's page in the orb registry
 version: 2.1
 
 orbs:
-  azure-aks: circleci/azure-aks@0.1.0
-  kubernetes: circleci/kubernetes@0.3.0
+  azure-aks: circleci/azure-aks@0.1.1
+  kubernetes: circleci/kubernetes@0.4.0
 
 jobs:
   create-deployment:

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -10,6 +10,9 @@ The following [project environment variables](https://circleci.com/docs/2.0/env-
 
 | Variable                       | Description                      |
 | -------------------------------| ---------------------------------|
+| `AZURE_SP`                     | Azure service principal          |
+| `AZURE_SP_PASSWORD`            | Azure service principal password |
+| `AZURE_SP_TENANT`              | Azure service principal tenant   |
 | `RESOURCE_NAME_PREFIX`     | Prefix for some resources created in tests. This is used just to make the project more portable.                |
 | `CIRCLECI_API_KEY`             | Used by the `queue` orb          |
 
@@ -19,9 +22,6 @@ The `orb-publishing` context is referenced in the build. In particular, the foll
 
 | Variable                       | Description                      |
 | -------------------------------| ---------------------------------|
-| `AZURE_SP`                     | Azure service principal          |
-| `AZURE_SP_PASSWORD`            | Azure service principal password |
-| `AZURE_SP_TENANT`              | Azure service principal tenant   |
 | `CIRCLE_TOKEN`                 | CircleCI API token used to publish the orb  |
 
 ### SSH configuration

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -10,8 +10,6 @@ The following [project environment variables](https://circleci.com/docs/2.0/env-
 
 | Variable                       | Description                      |
 | -------------------------------| ---------------------------------|
-| `AZURE_USERNAME`            | Azure user account name              |
-| `AZURE_PASSWORD`        | Azure user account password              |
 | `RESOURCE_NAME_PREFIX`     | Prefix for some resources created in tests. This is used just to make the project more portable.                |
 | `CIRCLECI_API_KEY`             | Used by the `queue` orb          |
 
@@ -21,6 +19,9 @@ The `orb-publishing` context is referenced in the build. In particular, the foll
 
 | Variable                       | Description                      |
 | -------------------------------| ---------------------------------|
+| `AZURE_SP`                     | Azure service principal          |
+| `AZURE_SP_PASSWORD`            | Azure service principal password |
+| `AZURE_SP_TENANT`              | Azure service principal tenant   |
 | `CIRCLE_TOKEN`                 | CircleCI API token used to publish the orb  |
 
 ### SSH configuration

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ description: |
 orbs:
   azure-cli: circleci/azure-cli@1.1.0
   helm: circleci/helm@0.1.0
-  kubernetes: circleci/kubernetes@0.3.0
+  kubernetes: circleci/kubernetes@0.4.0

--- a/src/examples/create-aks-cluster.yml
+++ b/src/examples/create-aks-cluster.yml
@@ -5,8 +5,8 @@ usage:
   version: 2.1
 
   orbs:
-    azure-aks: circleci/azure-aks@0.1.0
-    kubernetes: circleci/kubernetes@0.3.0
+    azure-aks: circleci/azure-aks@0.1.1
+    kubernetes: circleci/kubernetes@0.4.0
 
   jobs:
     test-cluster:

--- a/src/examples/create-k8s-deployment.yml
+++ b/src/examples/create-k8s-deployment.yml
@@ -5,8 +5,8 @@ usage:
   version: 2.1
 
   orbs:
-    azure-aks: circleci/azure-aks@0.1.0
-    kubernetes: circleci/kubernetes@0.3.0
+    azure-aks: circleci/azure-aks@0.1.1
+    kubernetes: circleci/kubernetes@0.4.0
 
   jobs:
     create-deployment:

--- a/src/examples/install-helm-chart.yml
+++ b/src/examples/install-helm-chart.yml
@@ -5,8 +5,8 @@ usage:
   version: 2.1
 
   orbs:
-    azure-aks: circleci/azure-aks@0.1.0
-    kubernetes: circleci/kubernetes@0.3.0
+    azure-aks: circleci/azure-aks@0.1.1
+    kubernetes: circleci/kubernetes@0.4.0
 
   workflows:
     deployment:


### PR DESCRIPTION
Upgrade kubernetes orb version to pull in a fix (See: https://github.com/CircleCI-Public/kubernetes-orb/pull/11) to address a bug with multiple container image updates

Also switched the project's environment variables to use service principal credentials due to recent issues with `az aks create` with the original user credentials (seemingly related to https://github.com/Azure/azure-cli/issues/10281 and https://github.com/Azure/azure-cli/issues/9585). Commented out the test of service principal deletion as these credentials likely do not have enough permissions to delete service principals. We can uncomment the test once we switch back to using a user.