### PR TITLE
[semver:minor] Update Microsoft Docker Hub namespace in `azure-docker` executor declaration

### DIFF
--- a/src/executors/azure-docker.yml
+++ b/src/executors/azure-docker.yml
@@ -1,4 +1,4 @@
 description: |
   Microsoft's Azure CLI Docker image
 docker:
-  - image: microsoft/azure-cli
+  - image: mcr.microsoft.com/azure-cli


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Azure Kubernetes Service Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [n/a] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The current executor declaration references an obsolete namespace for Microsoft's Azure CLI Docker image. This is preventing the image from being pulled.

Reported by a user:
- https://discuss.circleci.com/t/azure-cli-executor-is-not-working-in-azure-aks-orb/40386
- https://github.com/CircleCI-Public/azure-aks-orb/issues/11
 
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Update namespace in `azure-docker` executor declaration to `mcr.microsoft.com`.

Fixes #11 .